### PR TITLE
Update go-onedrive library to be aligned with spreadsheets requirements

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -5,20 +5,19 @@ import "errors"
 // error types
 
 var (
+	// ErrFileTooLarge represents the error returned when the file is too large for upload
 	ErrFileTooLarge = errors.New("file is too large for simple upload")
 )
 
-type innerError struct {
-	Code       string      `json:"code"`
-	Message    string      `json:"message"`
-	InnerError *innerError `json:"innererror"`
-}
-
 // The Error type defines the basic structure of errors that are returned from
 // the OneDrive API.
-// See: http://onedrive.github.io/misc/errors.htm
+// Error messages can be nested recursively, with inner errors containing more
+// specific error codes
+// See: https://docs.microsoft.com/en-gb/onedrive/developer/rest-api/concepts/errors?view=odsp-graph-online
 type Error struct {
-	innerError `json:"error"`
+	Code       string `json:"code"`
+	Message    string `json:"message"`
+	InnerError *Error `json:"innererror"`
 }
 
 func (e Error) Error() string {

--- a/onedrive.go
+++ b/onedrive.go
@@ -6,9 +6,8 @@ import (
 )
 
 const (
-	version   = "0.1"
-	baseURL   = "https://api.onedrive.com/v1.0"
-	userAgent = "github.com/ggordan/go-onedrive; version " + version
+	version = "0.1"
+	baseURL = "https://api.onedrive.com/v1.0"
 )
 
 // OneDrive is the entry point for the client. It manages the communication with
@@ -25,13 +24,12 @@ type OneDrive struct {
 	throttle time.Time
 }
 
-// NewOneDrive returns a new OneDrive client to enable you to communicate with
+// New returns a new OneDrive client to enable you to communicate with
 // the API
-func NewOneDrive(c *http.Client, debug bool) *OneDrive {
+func New(c *http.Client) *OneDrive {
 	drive := OneDrive{
 		Client:   c,
 		BaseURL:  baseURL,
-		Debug:    debug,
 		throttle: time.Now(),
 	}
 	drive.Drives = &DriveService{&drive}

--- a/onedrive_test.go
+++ b/onedrive_test.go
@@ -15,7 +15,7 @@ var (
 func setup() {
 	mux = http.NewServeMux()
 	server = httptest.NewServer(mux)
-	oneDrive = NewOneDrive(http.DefaultClient, true)
+	oneDrive = New(http.DefaultClient)
 	oneDrive.BaseURL = server.URL
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -1,6 +1,7 @@
 package onedrive
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -101,12 +102,12 @@ func TestThrottledRequest(t *testing.T) {
 		w.Write(b)
 	})
 
-	_, _, err := oneDrive.Drives.GetDefault()
+	_, _, err := oneDrive.Drives.GetDefault(context.Background())
 	if err == nil {
-		t.Fatal("Expected tooManyRequests error but none occured")
+		t.Fatal("Expected tooManyRequests error but none occurred")
 	}
 
-	drive, _, err := oneDrive.Drives.GetDefault()
+	drive, _, err := oneDrive.Drives.GetDefault(context.Background())
 	if drive != nil {
 		t.Fatalf("Expected no drive to be returned, got %v", *drive)
 	}


### PR DESCRIPTION
This PR aims to remove the copy pasted dependency on the go-onedrive library from spreadsheets, and be able to use a vendored  dependency instead. 

The changes represent the diff between the forked library and the existing changes in the spreadsheets repository (mostly to do with one drive business and context propagation).